### PR TITLE
add copy JSCS config statement in starter.sh

### DIFF
--- a/starter.sh
+++ b/starter.sh
@@ -12,6 +12,7 @@ cp $BASE/server.js index.js
 cp $BASE/fluxexapp.js fluxexapp.js
 echo "require('fluxex/extra/gulpfile');" > gulpfile.js
 cp $BASE/.jshintrc .
+cp $BASE/.jscsrc .
 
 echo '==================== THE STARTER PROJECT IS READY ===================='
 echo '= + index.js                    Your Server, add api URL here        ='


### PR DESCRIPTION
The statement is missed in starter.sh. This fails gulp task: lint_js while project is built by starter.sh.
