### PR TITLE
support AMD type module exports

### DIFF
--- a/lib/fluxstore.js
+++ b/lib/fluxstore.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var FluxexObject = require('./fluxobj'),
-    EventEmitter = require('eventemitter2').EventEmitter2,
+    EventEmitter = require('eventemitter2').EventEmitter2 || require('eventemitter2'),
 
 // jscs:disable checkRedundantParams
 /**


### PR DESCRIPTION
snippets of EventEmitter2 source code `eventemitter2.js`

``` javascript
  ...
  if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
    define(function() {
      return EventEmitter;
    });
  } else if (typeof exports === 'object') {
    // CommonJS
    exports.EventEmitter2 = EventEmitter;
  }
  else {
    // Browser global.
    window.EventEmitter2 = EventEmitter;
  }
```

For AMD module type export, should use `require('eventemitter2')` instead of `require('eventemitter2').EventEmitter2`, which has verified work for `webpack` to bundle
