### PR TITLE
[Fix Bug] avoid unnecessary internal routing for the different host which has the same route

### DIFF
--- a/examples/02-routing/components/TopProducts.jsx
+++ b/examples/02-routing/components/TopProducts.jsx
@@ -25,6 +25,8 @@ var TopProducts = React.createClass({
                 </li>);
         }
 
+        list.push(<li><a href="http://www.amazon.co.jp/product/111">Outsite Link</a></li>);
+        
         return (
         <div>
          <h1>Main site</h1>

--- a/extra/routeToURL.js
+++ b/extra/routeToURL.js
@@ -8,8 +8,13 @@
 // then add require('fluxex/extra/history'); in your fluxexapp.js
 
 module.exports = function (url) {
+    var currentHost = this.getStore('page')._get('url').host;
     // Try to route
     this.dispatch('UPDATE_URL', url).then(function () {
+        var newHost = this.getStore('page')._get('url').host;
+        if (currentHost !==  newHost) {
+            return Promise.reject('redirect to outsite link: ', url);
+        }
         // Run action to update page stores
         return this.executeAction(this.routing);
     }.bind(this)).then(function () {


### PR DESCRIPTION
# Issue Preview  (should not try to render a amazon route)

![image](https://cloud.githubusercontent.com/assets/1962079/12320806/a3ac42f4-bae5-11e5-9450-a8b79b0af84d.png)
# Reproduce flow:

1: click the link: http://www.amazon.co.jp/product/111
2: because we have the same route in example 2, it will match the internal product route (/extra/routing.js#L19) and emit page store change (/extra/routeToURL.js#L17)
3: page will be re-render for the internal product route, it is unnecessarily, in production site, it will cause PV be counted again.
# Major change: add host check
